### PR TITLE
upgraded zoc from 7.06.0 to 7.01.1

### DIFF
--- a/Casks/zoc.rb
+++ b/Casks/zoc.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'zoc' do
-  version '7.06.0'
-  sha256 '08549be9d919bae6761f4cac784ab1bbead1758e4938e130289114099ed44768'
+  version '7.07.1'
+  sha256 '9fd116b6960c8ee1a05a1601ad60a1881472a949cc4f1e8206ace84a0e47075c'
 
   url "http://www.emtec.com/downloads/zoc/zoc#{version.delete('.')}.dmg"
   name 'ZOC'


### PR DESCRIPTION
upgraded zoc from 7.06.0 to 7.01.1
Current version giving 404

==> Downloading http://www.emtec.com/downloads/zoc/zoc7060.dmg

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'zoc' with message: Download failed: http://www.emtec.com/downloads/zoc/zoc7060.dmg
